### PR TITLE
chore: migrate goreleaser to newest configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,6 @@
 ---
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
 archives:
   - id: archive
     name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
@@ -117,4 +119,4 @@ release:
   disable: false
   prerelease: auto
 snapshot:
-  name_template: "{{ .Tag }}-SNAPSHOT"
+  version_template: "{{ .Tag }}-SNAPSHOT"


### PR DESCRIPTION
The `goreleaser check` command was failing due to two reasons:

1. The version was not set.
2. `snapshot.name_template` got deprecated in v2.2

Therefore I fixed those issues to reduce the warnings in the Actions runner logs.