### PR TITLE
fix: improve HTTP response handling in webhook handlers

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -122,11 +122,8 @@ func (p *Webhook) Records(w http.ResponseWriter, r *http.Request) {
 	requestLog(r).Debugf("returning records count: %d", len(records))
 	w.Header().Set(contentTypeHeader, string(mediaTypeVersion1))
 	w.Header().Set(varyHeader, contentTypeHeader)
-	err = json.NewEncoder(w).Encode(records)
-	if err != nil {
+	if err = json.NewEncoder(w).Encode(records); err != nil {
 		requestLog(r).WithField(logFieldError, err).Error("error encoding records")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
 	}
 }
 
@@ -175,7 +172,6 @@ func (p *Webhook) AdjustEndpoints(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(contentTypeHeader, string(mediaTypeVersion1))
 	if err := json.NewEncoder(w).Encode(endpoints); err != nil {
 		requestLog(r).WithField(logFieldError, err).Error("error encoding endpoints")
-		w.WriteHeader(http.StatusInternalServerError)
 	}
 }
 
@@ -185,9 +181,16 @@ func (p *Webhook) Negotiate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	b, err := p.provider.GetDomainFilter().(*endpoint.DomainFilter).MarshalJSON()
+	df, ok := p.provider.GetDomainFilter().(*endpoint.DomainFilter)
+	if !ok {
+		requestLog(r).Error("failed to cast domain filter to *endpoint.DomainFilter")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	b, err := df.MarshalJSON()
 	if err != nil {
-		log.Errorf("failed to marshal domain filter, request method: %s, request path: %s", r.Method, r.URL.Path)
+		requestLog(r).WithField(logFieldError, err).Error("failed to marshal domain filter")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -195,8 +198,6 @@ func (p *Webhook) Negotiate(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(contentTypeHeader, string(mediaTypeVersion1))
 	if _, writeError := w.Write(b); writeError != nil {
 		requestLog(r).WithField(logFieldError, writeError).Error("error writing response")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
 	}
 }
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -120,10 +120,17 @@ func (p *Webhook) Records(w http.ResponseWriter, r *http.Request) {
 	}
 
 	requestLog(r).Debugf("returning records count: %d", len(records))
+	b, err := json.Marshal(records)
+	if err != nil {
+		requestLog(r).WithField(logFieldError, err).Error("error encoding records")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
 	w.Header().Set(contentTypeHeader, string(mediaTypeVersion1))
 	w.Header().Set(varyHeader, contentTypeHeader)
-	if err = json.NewEncoder(w).Encode(records); err != nil {
-		requestLog(r).WithField(logFieldError, err).Error("error encoding records")
+	if _, writeError := w.Write(b); writeError != nil {
+		requestLog(r).WithField(logFieldError, writeError).Error("error writing response")
 	}
 }
 
@@ -169,9 +176,16 @@ func (p *Webhook) AdjustEndpoints(w http.ResponseWriter, r *http.Request) {
 	}
 
 	requestLog(r).Debugf("adjust endpoints pass-through, count: %d", len(endpoints))
-	w.Header().Set(contentTypeHeader, string(mediaTypeVersion1))
-	if err := json.NewEncoder(w).Encode(endpoints); err != nil {
+	b, err := json.Marshal(endpoints)
+	if err != nil {
 		requestLog(r).WithField(logFieldError, err).Error("error encoding endpoints")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set(contentTypeHeader, string(mediaTypeVersion1))
+	if _, writeError := w.Write(b); writeError != nil {
+		requestLog(r).WithField(logFieldError, writeError).Error("error writing response")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Unsafe type assertion in `Negotiate`**: `GetDomainFilter()` result was cast to `*endpoint.DomainFilter` without a safety check, which would panic at runtime if the returned interface was a different type. Now uses the comma-ok pattern to return a 500 error instead of crashing.
- **Dead `WriteHeader` calls**: Three handlers (`Records`, `AdjustEndpoints`, `Negotiate`) called `w.WriteHeader(http.StatusInternalServerError)` after the response body had already been written via `json.Encode` or `w.Write`. Since Go's `net/http` implicitly sends a 200 status on first `Write`, these `WriteHeader` calls were no-ops that logged superfluous warnings. Removed the dead calls, keeping only the error logging.
- **Consistent logging**: Switched `Negotiate`'s marshal error log from `log.Errorf` to `requestLog(r)` for consistency with all other handlers.